### PR TITLE
Properly copy tooltip string into NOTIFYICONDATA.szTip

### DIFF
--- a/src/TrayIconFlyout.Shared/SystemTrayIcon.cs
+++ b/src/TrayIconFlyout.Shared/SystemTrayIcon.cs
@@ -108,7 +108,20 @@ namespace U5BFA.Libraries
 			data.guidItem = Id;
 			data.dwState = IsVisible ? 0U : NOTIFY_ICON_STATE.NIS_HIDDEN;
 			data.uFlags = NOTIFY_ICON_DATA_FLAGS.NIF_MESSAGE | NOTIFY_ICON_DATA_FLAGS.NIF_ICON | NOTIFY_ICON_DATA_FLAGS.NIF_TIP | NOTIFY_ICON_DATA_FLAGS.NIF_STATE | NOTIFY_ICON_DATA_FLAGS.NIF_GUID | NOTIFY_ICON_DATA_FLAGS.NIF_SHOWTIP;
-			data.szTip = Tooltip ?? string.Empty;
+
+			// Properly copy the tooltip string into the __char_128 struct
+			if (!string.IsNullOrEmpty(Tooltip))
+			{
+				var tipSpan = Tooltip.AsSpan();
+				int len = Math.Min(tipSpan.Length, 127); // __char_128 can hold up to 127 chars + null terminator
+				for (int i = 0; i < len; i++)
+					data.szTip.Value[i] = tipSpan[i];
+				data.szTip.Value[len] = '\0';
+			}
+			else
+			{
+				data.szTip.Value[0] = '\0';
+			}
 
 			if (_created)
 			{

--- a/src/TrayIconFlyout.Shared/SystemTrayIcon.cs
+++ b/src/TrayIconFlyout.Shared/SystemTrayIcon.cs
@@ -114,8 +114,8 @@ namespace U5BFA.Libraries
 			{
 				var tipSpan = Tooltip.AsSpan();
 				int len = Math.Min(tipSpan.Length, 127); // __char_128 can hold up to 127 chars + null terminator
-				for (int i = 0; i < len; i++)
-					data.szTip.Value[i] = tipSpan[i];
+				var destSpan = new Span<char>(data.szTip.Value, len);
+				tipSpan.Slice(0, len).CopyTo(destSpan);
 				data.szTip.Value[len] = '\0';
 			}
 			else


### PR DESCRIPTION
Updated tooltip assignment to explicitly copy the string into the szTip character array, enforcing the 127-character limit and null termination. This ensures correct handling and compatibility with native code.