### PR TITLE
Add MouseMoved event to SystemTrayIcon

### DIFF
--- a/src/TrayIconFlyout.Shared/SystemTrayIcon.cs
+++ b/src/TrayIconFlyout.Shared/SystemTrayIcon.cs
@@ -65,11 +65,12 @@ namespace U5BFA.Libraries
 		public event EventHandler? IconDestroyed;
 		public event EventHandler<MouseEventReceivedEventArgs>? LeftClicked;
 		public event EventHandler<MouseEventReceivedEventArgs>? RightClicked;
+        public event EventHandler<MouseEventReceivedEventArgs>? MouseMoved;
 
-		/// <summary>
-		/// Initializes a new instance of <see cref="SystemTrayIcon"/>.
-		/// </summary>
-		public SystemTrayIcon(string iconPath, string tooltip, Guid id, bool isVisible = true)
+        /// <summary>
+        /// Initializes a new instance of <see cref="SystemTrayIcon"/>.
+        /// </summary>
+        public SystemTrayIcon(string iconPath, string tooltip, Guid id, bool isVisible = true)
 		{
 			_taskbarRestartMessageId = PInvoke.RegisterWindowMessage((PCWSTR)Unsafe.AsPointer(ref Unsafe.AsRef(in "TaskbarCreated".GetPinnableReference())));
 			_wndProc = new(WndProc);
@@ -184,7 +185,15 @@ namespace U5BFA.Libraries
 					{
 						switch ((uint)LOWORD(lParam.Value))
 						{
-							case PInvoke.WM_LBUTTONUP:
+                            case PInvoke.WM_MOUSEMOVE:
+                                {
+                                    var point = GetCenterPointOfTrayIcon(hWnd);
+                                    if (!point.IsEmpty)
+                                        MouseMoved?.Invoke(this, new MouseEventReceivedEventArgs(point));
+
+                                    break;
+                                }
+                            case PInvoke.WM_LBUTTONUP:
 								{
 									PInvoke.SetForegroundWindow(hWnd);
 									var point = GetCenterPointOfTrayIcon(hWnd);


### PR DESCRIPTION
Introduced MouseMoved event, triggered on WM_MOUSEMOVE. The event provides mouse position data and is invoked when the tray icon receives mouse movement messages.