### PR TITLE
Add WPF usage note and link to related project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ You can consume this project via NuGet. Use NuGet Package Manager or run the fol
 > dotnet add package 0x5BFA.TrayIconFlyout.WinUI --prerelease
 ```
 
+> If you want to use the features in WPF, please check out https://github.com/Jack251970/TrayIconFlyout.Wpf.
+
 ## Usage
 
 There are two flyouts are available in this project. One is `TrayIconFlyout` for the Shell Flyout behavior, and the other is `TrayIconMenuFlyout` for the Context Menu behavior.


### PR DESCRIPTION
Added a section in the README.md to inform users about WPF support and direct them to the TrayIconFlyout.Wpf repository for WPF-specific features. This helps clarify usage options for different UI frameworks.