### PR TITLE
Add TrayIconFlyoutPopupDirection enum for popup control

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = crlf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[**/*.{cs,csx,vb}]
+indent_style = tab
+indent_size = 4
+tab_width = 4
+
+[**/*.xaml]
+indent_style = tab
+indent_size = 4
+tab_width = 4

--- a/TrayIconFlyout.slnx
+++ b/TrayIconFlyout.slnx
@@ -6,8 +6,7 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/.global/">
-    <File Path=".github/workflows/cd.yml" />
-    <File Path=".github/workflows/ci.yml" />
+    <File Path=".editorconfig" />
     <File Path="nuget.config" />
     <File Path="README.md" />
   </Folder>

--- a/samples/TrayIconFlyout.Wasdk.Sample.App/RootViewModel.cs
+++ b/samples/TrayIconFlyout.Wasdk.Sample.App/RootViewModel.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 using CommunityToolkit.Mvvm.ComponentModel;
-using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using System.Collections.Generic;
 using System.Linq;
@@ -32,8 +31,8 @@ namespace U5BFA.Libraries
 		[ObservableProperty]
 		internal partial int SelectedBackdropIndex { get; set; }
 
-		public Dictionary<Orientation, string> PopupDirections { get; private set; } = [];
-		public Dictionary<FlyoutPlacementMode, string> FlyoutPlacements { get; private set; } = [];
+        public Dictionary<TrayIconFlyoutPopupDirection, string> PopupDirections { get; private set; } = [];
+        public Dictionary<FlyoutPlacementMode, string> FlyoutPlacements { get; private set; } = [];
 		public Dictionary<BackdropKind, string> Backdrops { get; private set; } = [];
 
 		internal RootViewModel()
@@ -44,11 +43,13 @@ namespace U5BFA.Libraries
 			IsBackdropEnabled = true;
 			HideOnLostFocus = true;
 
-			PopupDirections.Add(Orientation.Vertical, "Vertical");
-			PopupDirections.Add(Orientation.Horizontal, "Horizontal");
-			SelectedPopupDirectionIndex = 0;
+            PopupDirections.Add(TrayIconFlyoutPopupDirection.Up, "Up");
+            PopupDirections.Add(TrayIconFlyoutPopupDirection.Down, "Down");
+            PopupDirections.Add(TrayIconFlyoutPopupDirection.Left, "Left");
+            PopupDirections.Add(TrayIconFlyoutPopupDirection.Right, "Right");
+            SelectedPopupDirectionIndex = 0;
 
-			FlyoutPlacements.Add(FlyoutPlacementMode.TopEdgeAlignedLeft, "Top left");
+            FlyoutPlacements.Add(FlyoutPlacementMode.TopEdgeAlignedLeft, "Top left");
 			FlyoutPlacements.Add(FlyoutPlacementMode.TopEdgeAlignedRight, "Top right");
 			FlyoutPlacements.Add(FlyoutPlacementMode.BottomEdgeAlignedLeft, "Bottom left");
 			FlyoutPlacements.Add(FlyoutPlacementMode.BottomEdgeAlignedRight, "Bottom right");

--- a/samples/TrayIconFlyout.Wasdk.Sample.App/RootViewModel.cs
+++ b/samples/TrayIconFlyout.Wasdk.Sample.App/RootViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 0x5BFA. All rights reserved.
+// Copyright (c) 0x5BFA. All rights reserved.
 // Licensed under the MIT license.
 
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -31,8 +31,8 @@ namespace U5BFA.Libraries
 		[ObservableProperty]
 		internal partial int SelectedBackdropIndex { get; set; }
 
-        public Dictionary<TrayIconFlyoutPopupDirection, string> PopupDirections { get; private set; } = [];
-        public Dictionary<FlyoutPlacementMode, string> FlyoutPlacements { get; private set; } = [];
+		public Dictionary<TrayIconFlyoutPopupDirection, string> PopupDirections { get; private set; } = [];
+		public Dictionary<FlyoutPlacementMode, string> FlyoutPlacements { get; private set; } = [];
 		public Dictionary<BackdropKind, string> Backdrops { get; private set; } = [];
 
 		internal RootViewModel()
@@ -43,13 +43,13 @@ namespace U5BFA.Libraries
 			IsBackdropEnabled = true;
 			HideOnLostFocus = true;
 
-            PopupDirections.Add(TrayIconFlyoutPopupDirection.Up, "Up");
-            PopupDirections.Add(TrayIconFlyoutPopupDirection.Down, "Down");
-            PopupDirections.Add(TrayIconFlyoutPopupDirection.Left, "Left");
-            PopupDirections.Add(TrayIconFlyoutPopupDirection.Right, "Right");
-            SelectedPopupDirectionIndex = 0;
+			PopupDirections.Add(TrayIconFlyoutPopupDirection.Up, "Up");
+			PopupDirections.Add(TrayIconFlyoutPopupDirection.Down, "Down");
+			PopupDirections.Add(TrayIconFlyoutPopupDirection.Left, "Left");
+			PopupDirections.Add(TrayIconFlyoutPopupDirection.Right, "Right");
+			SelectedPopupDirectionIndex = 0;
 
-            FlyoutPlacements.Add(FlyoutPlacementMode.TopEdgeAlignedLeft, "Top left");
+			FlyoutPlacements.Add(FlyoutPlacementMode.TopEdgeAlignedLeft, "Top left");
 			FlyoutPlacements.Add(FlyoutPlacementMode.TopEdgeAlignedRight, "Top right");
 			FlyoutPlacements.Add(FlyoutPlacementMode.BottomEdgeAlignedLeft, "Bottom left");
 			FlyoutPlacements.Add(FlyoutPlacementMode.BottomEdgeAlignedRight, "Bottom right");

--- a/src/TrayIconFlyout.Shared/TrayIconFlyout.Properties.cs
+++ b/src/TrayIconFlyout.Shared/TrayIconFlyout.Properties.cs
@@ -28,8 +28,8 @@ namespace U5BFA.Libraries
 		[GeneratedDependencyProperty(DefaultValue = true)]
 		public partial bool IsBackdropEnabled { get; set; }
 
-		[GeneratedDependencyProperty(DefaultValue = Orientation.Vertical)]
-		public partial Orientation PopupDirection { get; set; }
+		[GeneratedDependencyProperty(DefaultValue = TrayIconFlyoutPopupDirection.Up)]
+		public partial TrayIconFlyoutPopupDirection PopupDirection { get; set; }
 
 		[GeneratedDependencyProperty(DefaultValue = Orientation.Vertical)]
 		public partial Orientation IslandsOrientation { get; set; }

--- a/src/TrayIconFlyout.Shared/TrayIconFlyout.Shared.projitems
+++ b/src/TrayIconFlyout.Shared/TrayIconFlyout.Shared.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TrayIconFlyout.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TrayIconFlyout.Properties.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TrayIconFlyoutIsland.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TrayIconFlyoutPopupDirection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TrayIconMenuFlyout.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\WindowHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)XamlIslandApplication.cs" />

--- a/src/TrayIconFlyout.Shared/TrayIconFlyout.cs
+++ b/src/TrayIconFlyout.Shared/TrayIconFlyout.cs
@@ -152,6 +152,11 @@ namespace U5BFA.Libraries
 						storyboard.Completed += OpenAnimationStoryboard_Completed;
 						storyboard.Begin();
 					}
+					else
+					{
+						IsOpen = true;
+						_isPopupAnimationPlaying = false;
+					}
 				});
 			});
 		}
@@ -171,6 +176,12 @@ namespace U5BFA.Libraries
 					: TransitionHelpers.GetWindows11LeftToRightTransitionStoryboard(RootGrid, 0, (int)transformInfo.Size);
 				storyboard.Completed += CloseAnimationStoryboard_Completed;
 				storyboard.Begin();
+			}
+			else
+			{
+				_host?.UpdateWindowVisibility(false);
+				IsOpen = false;
+				_isPopupAnimationPlaying = false;
 			}
 		}
 

--- a/src/TrayIconFlyout.Shared/TrayIconFlyout.cs
+++ b/src/TrayIconFlyout.Shared/TrayIconFlyout.cs
@@ -9,6 +9,7 @@ using Windows.ApplicationModel.Core;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Markup;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
@@ -18,6 +19,7 @@ using Windows.Win32.UI.WindowsAndMessaging;
 using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Markup;
 using Microsoft.UI.Xaml.Media;
@@ -40,8 +42,10 @@ namespace U5BFA.Libraries
 		private bool? _wasTaskbarLightLastTimeChecked;
 		private bool? _wasTaskbarColorPrevalenceLastTimeChecked;
 		private bool _isPopupAnimationPlaying;
+        private TrayIconFlyoutPopupDirection _lastFlyoutPopupDirection;
+        private FlyoutPlacementMode _lastFlyoutPlacementMode;
 
-		private Grid? RootGrid;
+        private Grid? RootGrid;
 		private Grid? IslandsGrid;
 
 #if WASDK
@@ -84,7 +88,11 @@ namespace U5BFA.Libraries
 			_isPopupAnimationPlaying = true;
 			_host.Maximize();
 
-			_ = Task.Run(async () =>
+            // Cache the current animation and placement modes to ensure consistency during the animation
+            _lastFlyoutPopupDirection = PopupDirection;
+            _lastFlyoutPlacementMode = Placement;
+
+            _ = Task.Run(async () =>
 			{
 #if UWP
 				await RootGrid.Dispatcher.TryRunAsync(CoreDispatcherPriority.Normal, async () =>
@@ -101,27 +109,48 @@ namespace U5BFA.Libraries
 #endif
 					UpdateFlyoutRegion();
 
-					// Ensure to hide first
-					if (RootGrid.RenderTransform is TranslateTransform translateTransform)
-					{
-						if (PopupDirection is Orientation.Vertical)
-							translateTransform.Y = DesiredSize.Height;
-						else
-							translateTransform.X = DesiredSize.Width;
-					}
+                    // Ensure the render transform is a mutable TranslateTransform for animation
+                    if (RootGrid.RenderTransform is not TranslateTransform translateTransform)
+                    {
+                        RootGrid.RenderTransform = new TranslateTransform();
+                    }
+                    translateTransform = (TranslateTransform)RootGrid.RenderTransform;
+					
+					var transformOrientation = Orientation.Vertical;
+                    var transformSize = 0d;
+                    if (IsTransitionAnimationEnabled)
+                    {
+                        // Ensure to hide first and update the transform
+                        (transformOrientation, transformSize) = GetTranslateTransformInfo();
+                        if (transformOrientation is Orientation.Vertical)
+                        {
+                            translateTransform.X = 0;
+                            translateTransform.Y = transformSize;
+                        }
+                        else
+                        {
+                            translateTransform.X = transformSize;
+                            translateTransform.Y = 0;
+                        }
+                    }
+                    else
+                    {
+                        // Ensure the transform is reset to show the popup without animation
+                        translateTransform.X = translateTransform.Y = 0;
+                    }
 
-					UpdateLayout();
+                    UpdateLayout();
 					await Task.Delay(1);
 
 					_host.UpdateWindowVisibility(true);
 
 					if (IsTransitionAnimationEnabled)
 					{
-						var storyboard = PopupDirection is Orientation.Vertical
-							? TransitionHelpers.GetWindows11BottomToTopTransitionStoryboard(RootGrid, (int)DesiredSize.Height, 0)
-							: TransitionHelpers.GetWindows11RightToLeftTransitionStoryboard(RootGrid, (int)DesiredSize.Width, 0);
-						storyboard.Begin();
-						storyboard.Completed += OpenAnimationStoryboard_Completed;
+						var storyboard = transformOrientation is Orientation.Vertical
+                            ? TransitionHelpers.GetWindows11BottomToTopTransitionStoryboard(RootGrid, (int)transformSize, 0)
+							: TransitionHelpers.GetWindows11RightToLeftTransitionStoryboard(RootGrid, (int)transformSize, 0);
+                        storyboard.Completed += OpenAnimationStoryboard_Completed;
+                        storyboard.Begin();
 					}
 				});
 			});
@@ -136,13 +165,26 @@ namespace U5BFA.Libraries
 
 			if (IsTransitionAnimationEnabled)
 			{
-				var storyboard = PopupDirection is Orientation.Vertical
-					? TransitionHelpers.GetWindows11TopToBottomTransitionStoryboard(RootGrid, 0, (int)DesiredSize.Height)
-					: TransitionHelpers.GetWindows11LeftToRightTransitionStoryboard(RootGrid, 0, (int)DesiredSize.Width);
-				storyboard.Begin();
-				storyboard.Completed += CloseAnimationStoryboard_Completed;
+                var transformInfo = GetTranslateTransformInfo();
+                var storyboard = transformInfo.Orientation is Orientation.Vertical
+                    ? TransitionHelpers.GetWindows11TopToBottomTransitionStoryboard(RootGrid, 0, (int)transformInfo.Size)
+					: TransitionHelpers.GetWindows11LeftToRightTransitionStoryboard(RootGrid, 0, (int)transformInfo.Size);
+                storyboard.Completed += CloseAnimationStoryboard_Completed;
+                storyboard.Begin();
 			}
 		}
+
+        private (Orientation Orientation, double Size) GetTranslateTransformInfo()
+        {
+            return _lastFlyoutPopupDirection switch
+            {
+                TrayIconFlyoutPopupDirection.Up => (Orientation.Vertical, DesiredSize.Height),
+                TrayIconFlyoutPopupDirection.Down => (Orientation.Vertical, -DesiredSize.Height),
+                TrayIconFlyoutPopupDirection.Right => (Orientation.Horizontal, -DesiredSize.Width),
+                TrayIconFlyoutPopupDirection.Left => (Orientation.Horizontal, DesiredSize.Width),
+                _ => ((Orientation Orientation, double Size))(Orientation.Vertical, 0),
+            };
+        }
 
 #if UWP
 		public unsafe bool TryPreTranslateMessage(MSG* msg)
@@ -152,7 +194,7 @@ namespace U5BFA.Libraries
 #endif
 
 #if WASDK
-		private void UpdateBackdropManager(bool coerce = false)
+        private void UpdateBackdropManager(bool coerce = false)
 		{
 			var isTaskbarLight = GeneralHelpers.IsTaskbarLight();
 			var isTaskbarColorPrevalence = GeneralHelpers.IsTaskbarColorPrevalenceEnabled();

--- a/src/TrayIconFlyout.Shared/TrayIconFlyout.cs
+++ b/src/TrayIconFlyout.Shared/TrayIconFlyout.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 0x5BFA. All rights reserved.
+// Copyright (c) 0x5BFA. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -42,10 +42,10 @@ namespace U5BFA.Libraries
 		private bool? _wasTaskbarLightLastTimeChecked;
 		private bool? _wasTaskbarColorPrevalenceLastTimeChecked;
 		private bool _isPopupAnimationPlaying;
-        private TrayIconFlyoutPopupDirection _lastFlyoutPopupDirection;
-        private FlyoutPlacementMode _lastFlyoutPlacementMode;
+		private TrayIconFlyoutPopupDirection _lastFlyoutPopupDirection;
+		private FlyoutPlacementMode _lastFlyoutPlacementMode;
 
-        private Grid? RootGrid;
+		private Grid? RootGrid;
 		private Grid? IslandsGrid;
 
 #if WASDK
@@ -88,11 +88,11 @@ namespace U5BFA.Libraries
 			_isPopupAnimationPlaying = true;
 			_host.Maximize();
 
-            // Cache the current animation and placement modes to ensure consistency during the animation
-            _lastFlyoutPopupDirection = PopupDirection;
-            _lastFlyoutPlacementMode = Placement;
+			// Cache the current animation and placement modes to ensure consistency during the animation
+			_lastFlyoutPopupDirection = PopupDirection;
+			_lastFlyoutPlacementMode = Placement;
 
-            _ = Task.Run(async () =>
+			_ = Task.Run(async () =>
 			{
 #if UWP
 				await RootGrid.Dispatcher.TryRunAsync(CoreDispatcherPriority.Normal, async () =>
@@ -109,37 +109,37 @@ namespace U5BFA.Libraries
 #endif
 					UpdateFlyoutRegion();
 
-                    // Ensure the render transform is a mutable TranslateTransform for animation
-                    if (RootGrid.RenderTransform is not TranslateTransform translateTransform)
-                    {
-                        RootGrid.RenderTransform = new TranslateTransform();
-                    }
-                    translateTransform = (TranslateTransform)RootGrid.RenderTransform;
+					// Ensure the render transform is a mutable TranslateTransform for animation
+					if (RootGrid.RenderTransform is not TranslateTransform translateTransform)
+					{
+						RootGrid.RenderTransform = new TranslateTransform();
+					}
+					translateTransform = (TranslateTransform)RootGrid.RenderTransform;
 					
 					var transformOrientation = Orientation.Vertical;
-                    var transformSize = 0d;
-                    if (IsTransitionAnimationEnabled)
-                    {
-                        // Ensure to hide first and update the transform
-                        (transformOrientation, transformSize) = GetTranslateTransformInfo();
-                        if (transformOrientation is Orientation.Vertical)
-                        {
-                            translateTransform.X = 0;
-                            translateTransform.Y = transformSize;
-                        }
-                        else
-                        {
-                            translateTransform.X = transformSize;
-                            translateTransform.Y = 0;
-                        }
-                    }
-                    else
-                    {
-                        // Ensure the transform is reset to show the popup without animation
-                        translateTransform.X = translateTransform.Y = 0;
-                    }
+					var transformSize = 0d;
+					if (IsTransitionAnimationEnabled)
+					{
+						// Ensure to hide first and update the transform
+						(transformOrientation, transformSize) = GetTranslateTransformInfo();
+						if (transformOrientation is Orientation.Vertical)
+						{
+							translateTransform.X = 0;
+							translateTransform.Y = transformSize;
+						}
+						else
+						{
+							translateTransform.X = transformSize;
+							translateTransform.Y = 0;
+						}
+					}
+					else
+					{
+						// Ensure the transform is reset to show the popup without animation
+						translateTransform.X = translateTransform.Y = 0;
+					}
 
-                    UpdateLayout();
+					UpdateLayout();
 					await Task.Delay(1);
 
 					_host.UpdateWindowVisibility(true);
@@ -147,10 +147,10 @@ namespace U5BFA.Libraries
 					if (IsTransitionAnimationEnabled)
 					{
 						var storyboard = transformOrientation is Orientation.Vertical
-                            ? TransitionHelpers.GetWindows11BottomToTopTransitionStoryboard(RootGrid, (int)transformSize, 0)
+							? TransitionHelpers.GetWindows11BottomToTopTransitionStoryboard(RootGrid, (int)transformSize, 0)
 							: TransitionHelpers.GetWindows11RightToLeftTransitionStoryboard(RootGrid, (int)transformSize, 0);
-                        storyboard.Completed += OpenAnimationStoryboard_Completed;
-                        storyboard.Begin();
+						storyboard.Completed += OpenAnimationStoryboard_Completed;
+						storyboard.Begin();
 					}
 				});
 			});
@@ -165,26 +165,26 @@ namespace U5BFA.Libraries
 
 			if (IsTransitionAnimationEnabled)
 			{
-                var transformInfo = GetTranslateTransformInfo();
-                var storyboard = transformInfo.Orientation is Orientation.Vertical
-                    ? TransitionHelpers.GetWindows11TopToBottomTransitionStoryboard(RootGrid, 0, (int)transformInfo.Size)
+				var transformInfo = GetTranslateTransformInfo();
+				var storyboard = transformInfo.Orientation is Orientation.Vertical
+					? TransitionHelpers.GetWindows11TopToBottomTransitionStoryboard(RootGrid, 0, (int)transformInfo.Size)
 					: TransitionHelpers.GetWindows11LeftToRightTransitionStoryboard(RootGrid, 0, (int)transformInfo.Size);
-                storyboard.Completed += CloseAnimationStoryboard_Completed;
-                storyboard.Begin();
+				storyboard.Completed += CloseAnimationStoryboard_Completed;
+				storyboard.Begin();
 			}
 		}
 
-        private (Orientation Orientation, double Size) GetTranslateTransformInfo()
-        {
-            return _lastFlyoutPopupDirection switch
-            {
-                TrayIconFlyoutPopupDirection.Up => (Orientation.Vertical, DesiredSize.Height),
-                TrayIconFlyoutPopupDirection.Down => (Orientation.Vertical, -DesiredSize.Height),
-                TrayIconFlyoutPopupDirection.Right => (Orientation.Horizontal, -DesiredSize.Width),
-                TrayIconFlyoutPopupDirection.Left => (Orientation.Horizontal, DesiredSize.Width),
-                _ => ((Orientation Orientation, double Size))(Orientation.Vertical, 0),
-            };
-        }
+		private (Orientation Orientation, double Size) GetTranslateTransformInfo()
+		{
+			return _lastFlyoutPopupDirection switch
+			{
+				TrayIconFlyoutPopupDirection.Up => (Orientation.Vertical, DesiredSize.Height),
+				TrayIconFlyoutPopupDirection.Down => (Orientation.Vertical, -DesiredSize.Height),
+				TrayIconFlyoutPopupDirection.Right => (Orientation.Horizontal, -DesiredSize.Width),
+				TrayIconFlyoutPopupDirection.Left => (Orientation.Horizontal, DesiredSize.Width),
+				_ => ((Orientation Orientation, double Size))(Orientation.Vertical, 0),
+			};
+		}
 
 #if UWP
 		public unsafe bool TryPreTranslateMessage(MSG* msg)
@@ -194,7 +194,7 @@ namespace U5BFA.Libraries
 #endif
 
 #if WASDK
-        private void UpdateBackdropManager(bool coerce = false)
+		private void UpdateBackdropManager(bool coerce = false)
 		{
 			var isTaskbarLight = GeneralHelpers.IsTaskbarLight();
 			var isTaskbarColorPrevalence = GeneralHelpers.IsTaskbarColorPrevalenceEnabled();

--- a/src/TrayIconFlyout.Shared/TrayIconFlyoutPopupDirection.cs
+++ b/src/TrayIconFlyout.Shared/TrayIconFlyoutPopupDirection.cs
@@ -1,0 +1,28 @@
+﻿namespace U5BFA.Libraries
+{
+    /// <summary>
+    /// Defines the preferred popup direction of a <see cref="TrayIconFlyout"/>.
+    /// </summary>
+    public enum TrayIconFlyoutPopupDirection
+    {
+        /// <summary>
+        /// Preferred pop direction is upward.
+        /// </summary>
+        Up,
+
+        /// <summary>
+        /// Preferred pop direction is downward.
+        /// </summary>
+        Down,
+
+        /// <summary>
+        /// Preferred pop direction is to the right.
+        /// </summary>
+        Right,
+
+        /// <summary>
+        /// Preferred pop direction is to the left.
+        /// </summary>
+        Left,
+    }
+}

--- a/src/TrayIconFlyout.Shared/TrayIconFlyoutPopupDirection.cs
+++ b/src/TrayIconFlyout.Shared/TrayIconFlyoutPopupDirection.cs
@@ -1,28 +1,28 @@
-﻿namespace U5BFA.Libraries
+namespace U5BFA.Libraries
 {
-    /// <summary>
-    /// Defines the preferred popup direction of a <see cref="TrayIconFlyout"/>.
-    /// </summary>
-    public enum TrayIconFlyoutPopupDirection
-    {
-        /// <summary>
-        /// Preferred pop direction is upward.
-        /// </summary>
-        Up,
+	/// <summary>
+	/// Defines the preferred popup direction of a <see cref="TrayIconFlyout"/>.
+	/// </summary>
+	public enum TrayIconFlyoutPopupDirection
+	{
+		/// <summary>
+		/// Preferred pop direction is upward.
+		/// </summary>
+		Up,
 
-        /// <summary>
-        /// Preferred pop direction is downward.
-        /// </summary>
-        Down,
+		/// <summary>
+		/// Preferred pop direction is downward.
+		/// </summary>
+		Down,
 
-        /// <summary>
-        /// Preferred pop direction is to the right.
-        /// </summary>
-        Right,
+		/// <summary>
+		/// Preferred pop direction is to the right.
+		/// </summary>
+		Right,
 
-        /// <summary>
-        /// Preferred pop direction is to the left.
-        /// </summary>
-        Left,
-    }
+		/// <summary>
+		/// Preferred pop direction is to the left.
+		/// </summary>
+		Left,
+	}
 }


### PR DESCRIPTION
Replaced Orientation with TrayIconFlyoutPopupDirection for popup direction, enabling Up, Down, Left, and Right options. Updated properties, dictionaries, and animation logic in RootViewModel and TrayIconFlyout to use the new enum. Added GetTranslateTransformInfo helper and included the enum file in the project. Animation now supports all four directions.

Resolve #3