### PR TITLE
Ensure island is set as foreground if it is visible and being activated

### DIFF
--- a/src/DesktopFlyouts.Shared/XamlIslandHostWindow.cs
+++ b/src/DesktopFlyouts.Shared/XamlIslandHostWindow.cs
@@ -266,7 +266,8 @@ namespace DesktopFlyouts
                 : SHOW_WINDOW_CMD.SW_HIDE;
 
             PInvoke.ShowWindow(HWnd, command);
-
+            if (isVisible && activate)
+                PInvoke.SetForegroundWindow(HWnd);
 #if UWP
             PInvoke.ShowWindow(_xamlHwnd, command);
 #else


### PR DESCRIPTION
Without this change the flyout behaved as if `NoActivateOnOpen` was always set. I think there is a race condition somewhere or focus being set out of order that causes this issue but I was unable to track it down.