### PR TITLE
Use ItemsControl & support island visibility change at runtime

### DIFF
--- a/samples/DesktopFlyouts.Wasdk.Sample.App/Views/CustomizableFlyout.xaml
+++ b/samples/DesktopFlyouts.Wasdk.Sample.App/Views/CustomizableFlyout.xaml
@@ -10,27 +10,43 @@
     mc:Ignorable="d">
 
     <local:DesktopFlyout.Islands>
-        <local:DesktopFlyoutIsland IslandHeight="*">
-            <Button
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                Content="Button">
-                <Button.Flyout>
-                    <MenuFlyout>
-                        <MenuFlyoutItem Text="A" />
-                        <MenuFlyoutItem Text="A" />
-                        <MenuFlyoutItem Text="A" />
-                    </MenuFlyout>
-                </Button.Flyout>
-            </Button>
+        <local:DesktopFlyoutIsland x:Name="FirstIsland" IslandHeight="*">
+            <Grid>
+                <Button
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Content="Button">
+                    <Button.Flyout>
+                        <MenuFlyout>
+                            <MenuFlyoutItem Text="A" />
+                            <MenuFlyoutItem Text="A" />
+                            <MenuFlyoutItem Text="A" />
+                        </MenuFlyout>
+                    </Button.Flyout>
+                </Button>
+                <Button
+                    Margin="12"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Top"
+                    Click="CollapseFirstIslandButton_Click"
+                    Content="Collapse" />
+            </Grid>
         </local:DesktopFlyoutIsland>
-        <local:DesktopFlyoutIsland IslandHeight="300">
-            <TextBlock
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                Text="Island 2" />
+        <local:DesktopFlyoutIsland x:Name="SecondIsland" IslandHeight="300">
+            <Grid>
+                <TextBlock
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    Text="Island 2" />
+                <Button
+                    Margin="12"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Top"
+                    Click="CollapseSecondIslandButton_Click"
+                    Content="Collapse" />
+            </Grid>
         </local:DesktopFlyoutIsland>
-        <local:DesktopFlyoutIsland IslandHeight="300">
+        <local:DesktopFlyoutIsland x:Name="ThirdIsland" IslandHeight="300">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="*" />
@@ -71,6 +87,14 @@
                         Content="Learn more" />
                     <CalendarDatePicker />
                 </StackPanel>
+
+                <Button
+                    Grid.Row="4"
+                    Margin="6,0,0,0"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Center"
+                    Click="CollapseThirdIslandButton_Click"
+                    Content="Collapse" />
 
                 <Button
                     Grid.Row="4"

--- a/samples/DesktopFlyouts.Wasdk.Sample.App/Views/CustomizableFlyout.xaml.cs
+++ b/samples/DesktopFlyouts.Wasdk.Sample.App/Views/CustomizableFlyout.xaml.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 0x5BFA. All rights reserved.
 // Licensed under the MIT license.
 
+using Microsoft.UI.Xaml;
+
 namespace DesktopFlyouts
 {
     public sealed partial class CustomizableFlyout : DesktopFlyout
@@ -8,6 +10,21 @@ namespace DesktopFlyouts
         public CustomizableFlyout()
         {
             InitializeComponent();
+        }
+
+        private void CollapseFirstIslandButton_Click(object sender, RoutedEventArgs e)
+        {
+            FirstIsland.Visibility = Visibility.Collapsed;
+        }
+
+        private void CollapseSecondIslandButton_Click(object sender, RoutedEventArgs e)
+        {
+            SecondIsland.Visibility = Visibility.Collapsed;
+        }
+
+        private void CollapseThirdIslandButton_Click(object sender, RoutedEventArgs e)
+        {
+            ThirdIsland.Visibility = Visibility.Collapsed;
         }
     }
 }

--- a/src/DesktopFlyouts.Shared/DesktopFlyout.cs
+++ b/src/DesktopFlyouts.Shared/DesktopFlyout.cs
@@ -329,32 +329,61 @@ namespace DesktopFlyouts
 
             if (IslandsOrientation is Orientation.Vertical)
             {
-                for (int index = 0; index < Islands.Count; index++)
+                var visibleIndex = 0;
+
+                for (var index = 0; index < Islands.Count; index++)
                 {
                     if (Islands[index] is not DesktopFlyoutIsland island)
                         continue;
 
-                    IslandsGrid.RowDefinitions.Add(new() { Height = island.IslandHeight });
-                    Grid.SetRow(island, index);
-                    Grid.SetColumn(island, 0);
                     island.SetOwner(this);
+
+                    if (IsIslandVisible(island))
+                    {
+                        IslandsGrid.RowDefinitions.Add(new() { Height = island.IslandHeight });
+                        Grid.SetRow(island, visibleIndex);
+                        visibleIndex++;
+                    }
+                    else
+                    {
+                        Grid.SetRow(island, 0);
+                    }
+
+                    Grid.SetColumn(island, 0);
                     IslandsGrid.Children.Add(island);
                 }
+
+                if (visibleIndex == 0 && IslandsGrid.Children.Count > 0)
+                    IslandsGrid.RowDefinitions.Add(new() { Height = new GridLength(0) });
             }
             else
             {
-                for (int index = 0; index < Islands.Count; index++)
-                {
+                var visibleIndex = 0;
 
+                for (var index = 0; index < Islands.Count; index++)
+                {
                     if (Islands[index] is not DesktopFlyoutIsland island)
                         continue;
 
-                    IslandsGrid.ColumnDefinitions.Add(new() { Width = island.IslandWidth });
-                    Grid.SetRow(island, 0);
-                    Grid.SetColumn(island, index);
                     island.SetOwner(this);
+
+                    if (IsIslandVisible(island))
+                    {
+                        IslandsGrid.ColumnDefinitions.Add(new() { Width = island.IslandWidth });
+                        Grid.SetColumn(island, visibleIndex);
+                        visibleIndex++;
+                    }
+                    else
+                    {
+                        Grid.SetColumn(island, 0);
+                    }
+
+                    Grid.SetRow(island, 0);
                     IslandsGrid.Children.Add(island);
                 }
+
+                if (visibleIndex == 0 && IslandsGrid.Children.Count > 0)
+                    IslandsGrid.ColumnDefinitions.Add(new() { Width = new GridLength(0) });
             }
         }
 
@@ -418,6 +447,12 @@ namespace DesktopFlyouts
             UpdateOpenFlyoutLayout();
         }
 
+        internal void OnIslandVisibilityChanged()
+        {
+            UpdateIslands();
+            UpdateOpenFlyoutLayout();
+        }
+
         private void UpdateOpenFlyoutLayout()
         {
             if (!IsOpen || _isPopupAnimationPlaying || RootGrid is null || _host?.DesktopWindowXamlSource is null)
@@ -467,7 +502,7 @@ namespace DesktopFlyouts
         {
             foreach (var item in Islands)
             {
-                if (item is DesktopFlyoutIsland island && island.IslandWidth.IsStar)
+                if (item is DesktopFlyoutIsland island && IsIslandVisible(island) && island.IslandWidth.IsStar)
                     return true;
             }
 
@@ -478,11 +513,16 @@ namespace DesktopFlyouts
         {
             foreach (var item in Islands)
             {
-                if (item is DesktopFlyoutIsland island && island.IslandHeight.IsStar)
+                if (item is DesktopFlyoutIsland island && IsIslandVisible(island) && island.IslandHeight.IsStar)
                     return true;
             }
 
             return false;
+        }
+
+        private static bool IsIslandVisible(DesktopFlyoutIsland island)
+        {
+            return island.Visibility is Visibility.Visible;
         }
 
         private void OpenAnimationStoryboard_Completed(object? sender, object e)

--- a/src/DesktopFlyouts.Shared/DesktopFlyout.cs
+++ b/src/DesktopFlyouts.Shared/DesktopFlyout.cs
@@ -45,7 +45,7 @@ namespace DesktopFlyouts
     public partial class DesktopFlyout : Control, IDisposable
     {
         private const string PART_RootGrid = "PART_RootGrid";
-        private const string PART_IslandsGrid = "PART_IslandsGrid";
+        private const string PART_IslandsItemsControl = "PART_IslandsItemsControl";
         private const double SwipeDismissDragStartThreshold = 4.0D;
         private const double SwipeDismissAxisDominanceRatio = 1.2D;
 
@@ -70,7 +70,7 @@ namespace DesktopFlyouts
         private bool _disposed;
 
         private Grid? RootGrid;
-        private Grid? IslandsGrid;
+        private ItemsControl? IslandsItemsControl;
 
         /// <summary>
         /// Initializes a new instance of <see cref="DesktopFlyout"/>.
@@ -101,11 +101,14 @@ namespace DesktopFlyouts
             RootGrid?.PointerCanceled -= RootGrid_PointerCanceled;
             RootGrid?.PointerCaptureLost -= RootGrid_PointerCaptureLost;
             RootGrid?.PointerExited -= RootGrid_PointerExited;
+            if (IslandsItemsControl is not null)
+                IslandsItemsControl.ItemsSource = null;
 
             RootGrid = GetTemplateChild(PART_RootGrid) as Grid
                 ?? throw new MissingFieldException($"Could not find {PART_RootGrid} in the given {nameof(DesktopFlyout)}'s style.");
-            IslandsGrid = GetTemplateChild(PART_IslandsGrid) as Grid
-                ?? throw new MissingFieldException($"Could not find {PART_IslandsGrid} in the given {nameof(DesktopFlyout)}'s style.");
+            IslandsItemsControl = GetTemplateChild(PART_IslandsItemsControl) as ItemsControl
+                ?? throw new MissingFieldException($"Could not find {PART_IslandsItemsControl} in the given {nameof(DesktopFlyout)}'s style.");
+            IslandsItemsControl.ItemsSource = Islands;
 
             EnsureRootTransform();
 
@@ -320,76 +323,21 @@ namespace DesktopFlyouts
 
         private void UpdateIslands()
         {
-            if (IslandsGrid is null)
+            if (IslandsItemsControl is null)
                 return;
 
-            IslandsGrid.Children.Clear();
-            IslandsGrid.RowDefinitions.Clear();
-            IslandsGrid.ColumnDefinitions.Clear();
-
-            if (IslandsOrientation is Orientation.Vertical)
+            for (var index = 0; index < Islands.Count; index++)
             {
-                var visibleIndex = 0;
-
-                for (var index = 0; index < Islands.Count; index++)
-                {
-                    if (Islands[index] is not DesktopFlyoutIsland island)
-                        continue;
-
+                if (Islands[index] is DesktopFlyoutIsland island)
                     island.SetOwner(this);
-
-                    if (IsIslandVisible(island))
-                    {
-                        IslandsGrid.RowDefinitions.Add(new() { Height = island.IslandHeight });
-                        Grid.SetRow(island, visibleIndex);
-                        visibleIndex++;
-                    }
-                    else
-                    {
-                        Grid.SetRow(island, 0);
-                    }
-
-                    Grid.SetColumn(island, 0);
-                    IslandsGrid.Children.Add(island);
-                }
-
-                if (visibleIndex == 0 && IslandsGrid.Children.Count > 0)
-                    IslandsGrid.RowDefinitions.Add(new() { Height = new GridLength(0) });
             }
-            else
-            {
-                var visibleIndex = 0;
 
-                for (var index = 0; index < Islands.Count; index++)
-                {
-                    if (Islands[index] is not DesktopFlyoutIsland island)
-                        continue;
-
-                    island.SetOwner(this);
-
-                    if (IsIslandVisible(island))
-                    {
-                        IslandsGrid.ColumnDefinitions.Add(new() { Width = island.IslandWidth });
-                        Grid.SetColumn(island, visibleIndex);
-                        visibleIndex++;
-                    }
-                    else
-                    {
-                        Grid.SetColumn(island, 0);
-                    }
-
-                    Grid.SetRow(island, 0);
-                    IslandsGrid.Children.Add(island);
-                }
-
-                if (visibleIndex == 0 && IslandsGrid.Children.Count > 0)
-                    IslandsGrid.ColumnDefinitions.Add(new() { Width = new GridLength(0) });
-            }
+            IslandsItemsControl.InvalidateMeasure();
         }
 
         private DesktopFlyoutPopupDirection UpdateFlyoutRegion()
         {
-            if (_host?.DesktopWindowXamlSource is null || IslandsGrid is null)
+            if (_host?.DesktopWindowXamlSource is null || IslandsItemsControl is null)
                 return ResolvePopupDirection(PopupDirection, default, WindowHelpers.GetFlyoutWorkAreaRect(_customPlacementBottomCenterPoint));
 
             var customBottomCenterPoint = _customPlacementBottomCenterPoint;
@@ -1314,6 +1262,8 @@ namespace DesktopFlyouts
             RootGrid?.PointerCanceled -= RootGrid_PointerCanceled;
             RootGrid?.PointerCaptureLost -= RootGrid_PointerCaptureLost;
             RootGrid?.PointerExited -= RootGrid_PointerExited;
+            if (IslandsItemsControl is not null)
+                IslandsItemsControl.ItemsSource = null;
 
             if (_isFocusManagerGettingFocusSubscribed)
             {

--- a/src/DesktopFlyouts.Shared/DesktopFlyoutIsland.cs
+++ b/src/DesktopFlyouts.Shared/DesktopFlyoutIsland.cs
@@ -44,6 +44,7 @@ namespace DesktopFlyouts
         public DesktopFlyoutIsland()
         {
             DefaultStyleKey = typeof(DesktopFlyoutIsland);
+            RegisterPropertyChangedCallback(VisibilityProperty, (s, e) => ((DesktopFlyoutIsland)s).OnIslandVisibilityChanged());
             UpdateTemplateSettings();
         }
 
@@ -80,6 +81,12 @@ namespace DesktopFlyouts
         private void OnCornerRadiusChanged()
         {
             UpdateTemplateSettings();
+        }
+
+        private void OnIslandVisibilityChanged()
+        {
+            if (_owner is not null && _owner.TryGetTarget(out var owner))
+                owner.OnIslandVisibilityChanged();
         }
 
         private void UpdateTemplateSettings()

--- a/src/DesktopFlyouts.Shared/DesktopFlyoutIslandsPanel.cs
+++ b/src/DesktopFlyouts.Shared/DesktopFlyoutIslandsPanel.cs
@@ -1,0 +1,314 @@
+// Copyright (c) 0x5BFA. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Windows.Foundation;
+
+#if UWP
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+#elif WASDK
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+#endif
+
+namespace DesktopFlyouts
+{
+    /// <summary>
+    /// Arranges <see cref="DesktopFlyoutIsland"/> items for a <see cref="DesktopFlyout"/>.
+    /// </summary>
+    public partial class DesktopFlyoutIslandsPanel : Panel
+    {
+        /// <summary>
+        /// Identifies the <see cref="Orientation"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty OrientationProperty =
+            DependencyProperty.Register(nameof(Orientation), typeof(Orientation), typeof(DesktopFlyoutIslandsPanel), new PropertyMetadata(Orientation.Vertical, OnLayoutPropertyChanged));
+
+        /// <summary>
+        /// Gets or sets the fallback orientation used when the panel is not hosted by a <see cref="DesktopFlyout"/>.
+        /// </summary>
+        public Orientation Orientation
+        {
+            get => (Orientation)GetValue(OrientationProperty);
+            set => SetValue(OrientationProperty, value);
+        }
+
+        /// <summary>
+        /// Identifies the <see cref="Spacing"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty SpacingProperty =
+            DependencyProperty.Register(nameof(Spacing), typeof(double), typeof(DesktopFlyoutIslandsPanel), new PropertyMetadata(0D, OnLayoutPropertyChanged));
+
+        /// <summary>
+        /// Gets or sets the spacing between visible islands.
+        /// </summary>
+        public double Spacing
+        {
+            get => (double)GetValue(SpacingProperty);
+            set => SetValue(SpacingProperty, value);
+        }
+
+        /// <inheritdoc/>
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            return GetResolvedOrientation() is Orientation.Vertical
+                ? MeasureStack(availableSize, isVertical: true)
+                : MeasureStack(availableSize, isVertical: false);
+        }
+
+        /// <inheritdoc/>
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            return GetResolvedOrientation() is Orientation.Vertical
+                ? ArrangeStack(finalSize, isVertical: true)
+                : ArrangeStack(finalSize, isVertical: false);
+        }
+
+        private Size MeasureStack(Size availableSize, bool isVertical)
+        {
+            var items = GetVisibleItems(isVertical, shouldMeasureCollapsedItems: true);
+            var spacing = GetResolvedSpacing();
+            var spacingTotal = GetSpacingTotal(items.Count, spacing);
+            var availableLength = GetLength(availableSize, isVertical);
+            var availableCross = GetCrossLength(availableSize, isVertical);
+            var hasFiniteLength = !double.IsInfinity(availableLength);
+            var fixedLength = 0D;
+            var autoLength = 0D;
+            var starLength = 0D;
+            var starWeight = 0D;
+            var desiredCross = 0D;
+
+            foreach (var item in items)
+            {
+                if (item.Length.IsStar)
+                {
+                    starWeight += Math.Max(0D, item.Length.Value);
+                    continue;
+                }
+
+                if (item.Length.IsAuto)
+                {
+                    item.Element.Measure(CreateSize(availableCross, double.PositiveInfinity, isVertical));
+                    autoLength += GetLength(item.Element.DesiredSize, isVertical);
+                }
+                else
+                {
+                    var length = Math.Max(0D, item.Length.Value);
+                    item.Element.Measure(CreateSize(availableCross, length, isVertical));
+                    fixedLength += length;
+                }
+
+                desiredCross = Math.Max(desiredCross, GetCrossLength(item.Element.DesiredSize, isVertical));
+            }
+
+            var remainingLength = hasFiniteLength
+                ? Math.Max(0D, availableLength - fixedLength - autoLength - spacingTotal)
+                : double.PositiveInfinity;
+
+            foreach (var item in items)
+            {
+                if (!item.Length.IsStar)
+                    continue;
+
+                var allocatedLength = hasFiniteLength
+                    ? GetWeightedLength(remainingLength, item.Length, starWeight)
+                    : double.PositiveInfinity;
+
+                item.Element.Measure(CreateSize(availableCross, allocatedLength, isVertical));
+                var measuredLength = hasFiniteLength
+                    ? allocatedLength
+                    : GetLength(item.Element.DesiredSize, isVertical);
+
+                starLength += measuredLength;
+                desiredCross = Math.Max(desiredCross, GetCrossLength(item.Element.DesiredSize, isVertical));
+            }
+
+            var desiredLength = fixedLength + autoLength + starLength + spacingTotal;
+            return CreateSize(desiredCross, desiredLength, isVertical);
+        }
+
+        private Size ArrangeStack(Size finalSize, bool isVertical)
+        {
+            var items = GetVisibleItems(isVertical, shouldMeasureCollapsedItems: false);
+            var spacing = GetResolvedSpacing();
+            var spacingTotal = GetSpacingTotal(items.Count, spacing);
+            var finalLength = GetLength(finalSize, isVertical);
+            var finalCross = GetCrossLength(finalSize, isVertical);
+            var fixedLength = 0D;
+            var autoLength = 0D;
+            var starWeight = 0D;
+
+            foreach (var item in items)
+            {
+                if (item.Length.IsStar)
+                {
+                    starWeight += Math.Max(0D, item.Length.Value);
+                }
+                else if (item.Length.IsAuto)
+                {
+                    autoLength += GetLength(item.Element.DesiredSize, isVertical);
+                }
+                else
+                {
+                    fixedLength += Math.Max(0D, item.Length.Value);
+                }
+            }
+
+            var remainingLength = Math.Max(0D, finalLength - fixedLength - autoLength - spacingTotal);
+            var offset = 0D;
+
+            foreach (var item in items)
+            {
+                var length = item.Length.IsStar
+                    ? GetWeightedLength(remainingLength, item.Length, starWeight)
+                    : item.Length.IsAuto
+                        ? GetLength(item.Element.DesiredSize, isVertical)
+                        : Math.Max(0D, item.Length.Value);
+
+                item.Element.Arrange(CreateRect(offset, finalCross, length, isVertical));
+                offset += length + spacing;
+            }
+
+            ArrangeCollapsedItems();
+
+            return finalSize;
+        }
+
+        private List<LayoutItem> GetVisibleItems(bool isVertical, bool shouldMeasureCollapsedItems)
+        {
+            var items = new List<LayoutItem>();
+
+            foreach (var child in Children)
+            {
+                if (child is not UIElement element)
+                    continue;
+
+                var island = GetIsland(element);
+                if (island is null || island.Visibility is Visibility.Visible)
+                {
+                    var length = isVertical
+                        ? island?.IslandHeight ?? GridLength.Auto
+                        : island?.IslandWidth ?? GridLength.Auto;
+
+                    items.Add(new(element, length));
+                }
+                else if (shouldMeasureCollapsedItems)
+                {
+                    element.Measure(new(0, 0));
+                }
+            }
+
+            return items;
+        }
+
+        private void ArrangeCollapsedItems()
+        {
+            foreach (var child in Children)
+            {
+                if (child is not UIElement element)
+                    continue;
+
+                var island = GetIsland(element);
+                if (island is not null && island.Visibility is not Visibility.Visible)
+                    element.Arrange(new(0, 0, 0, 0));
+            }
+        }
+
+        private Orientation GetResolvedOrientation()
+        {
+            return GetOwnerFlyout()?.IslandsOrientation ?? Orientation;
+        }
+
+        private DesktopFlyout? GetOwnerFlyout()
+        {
+            DependencyObject? current = this;
+
+            while (current is not null)
+            {
+                if (current is DesktopFlyout flyout)
+                    return flyout;
+
+                current = VisualTreeHelper.GetParent(current);
+            }
+
+            return null;
+        }
+
+        private static DesktopFlyoutIsland? GetIsland(UIElement element)
+        {
+            return element switch
+            {
+                DesktopFlyoutIsland island => island,
+                ContentPresenter { Content: DesktopFlyoutIsland island } => island,
+                _ => null,
+            };
+        }
+
+        private static double GetWeightedLength(double availableLength, GridLength length, double totalWeight)
+        {
+            return totalWeight > 0D
+                ? availableLength * (Math.Max(0D, length.Value) / totalWeight)
+                : 0D;
+        }
+
+        private double GetResolvedSpacing()
+        {
+            return double.IsNaN(Spacing) || double.IsInfinity(Spacing)
+                ? 0D
+                : Math.Max(0D, Spacing);
+        }
+
+        private static double GetSpacingTotal(int count, double spacing)
+        {
+            return Math.Max(0, count - 1) * spacing;
+        }
+
+        private static double GetLength(Size size, bool isVertical)
+        {
+            return isVertical ? size.Height : size.Width;
+        }
+
+        private static double GetCrossLength(Size size, bool isVertical)
+        {
+            return isVertical ? size.Width : size.Height;
+        }
+
+        private static Size CreateSize(double cross, double length, bool isVertical)
+        {
+            return isVertical
+                ? new(cross, length)
+                : new(length, cross);
+        }
+
+        private static Rect CreateRect(double offset, double cross, double length, bool isVertical)
+        {
+            return isVertical
+                ? new(0, offset, cross, length)
+                : new(offset, 0, length, cross);
+        }
+
+        private static void OnLayoutPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs e)
+        {
+            if (dependencyObject is not DesktopFlyoutIslandsPanel panel)
+                return;
+
+            panel.InvalidateMeasure();
+        }
+
+        private readonly struct LayoutItem
+        {
+            public LayoutItem(UIElement element, GridLength length)
+            {
+                Element = element;
+                Length = length;
+            }
+
+            public UIElement Element { get; }
+            public GridLength Length { get; }
+        }
+    }
+}

--- a/src/DesktopFlyouts.Shared/DesktopFlyouts.Shared.projitems
+++ b/src/DesktopFlyouts.Shared/DesktopFlyouts.Shared.projitems
@@ -24,6 +24,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\TransitionHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DesktopFlyout.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DesktopFlyout.Properties.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DesktopFlyoutIslandsPanel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DesktopFlyoutIsland.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DesktopFlyoutIslandTemplateSettings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DesktopMenuFlyout.cs" />

--- a/src/DesktopFlyouts.Shared/SystemTrayIcon.cs
+++ b/src/DesktopFlyouts.Shared/SystemTrayIcon.cs
@@ -24,7 +24,7 @@ namespace DesktopFlyouts
     /// <see cref="Destroy"/> to remove it. Call <see cref="Dispose()"/> explicitly when the object
     /// is no longer needed to release its owned resources.
     /// </remarks>
-    public partial class SystemTrayIcon : IDisposable
+    public unsafe partial class SystemTrayIcon : IDisposable
     {
         private const uint WM_UNIQUE_MESSAGE = 2048U;
 

--- a/src/DesktopFlyouts.Uwp/DesktopFlyout.xaml
+++ b/src/DesktopFlyouts.Uwp/DesktopFlyout.xaml
@@ -33,10 +33,15 @@
                                 TranslateY="0" />
                         </Grid.RenderTransform>
 
-                        <Grid
-                            x:Name="PART_IslandsGrid"
-                            ColumnSpacing="12"
-                            RowSpacing="12" />
+                        <ItemsControl
+                            x:Name="PART_IslandsItemsControl"
+                            IsTabStop="False">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <local:DesktopFlyoutIslandsPanel Spacing="12" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                        </ItemsControl>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>

--- a/src/DesktopFlyouts.Wasdk/DesktopFlyout.xaml
+++ b/src/DesktopFlyouts.Wasdk/DesktopFlyout.xaml
@@ -35,10 +35,15 @@
                                 TranslateY="0" />
                         </Grid.RenderTransform>
 
-                        <Grid
-                            x:Name="PART_IslandsGrid"
-                            ColumnSpacing="12"
-                            RowSpacing="12" />
+                        <ItemsControl
+                            x:Name="PART_IslandsItemsControl"
+                            IsTabStop="False">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <local:DesktopFlyoutIslandsPanel Spacing="12" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                        </ItemsControl>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
This PR adds support for changing `DesktopFlyoutIsland.Visibility` while a flyout is open.

Collapsed islands are excluded from the generated `Grid` rows/columns, so remaining visible islands are reindexed and the open flyout is remeasured/repositioned. Hidden islands remain in the flyout tree on a non-layout row/column so they can still notify the owner when their visibility changes back to `Visible`.

Validation performed locally:

- `dotnet msbuild /restore:false samples\DesktopFlyouts.Wasdk.Sample.App\DesktopFlyouts.Wasdk.Sample.App.csproj /p:Configuration=Debug /p:Platform=x64 /p:AppxBundle=Never`
- `dotnet msbuild /restore:false src\DesktopFlyouts.Uwp\DesktopFlyouts.Uwp.csproj /p:Configuration=Debug /p:Platform=x64 /p:AppxBundle=Never`
- registered and launched the WASDK packaged sample through `shell:AppsFolder`; process was responsive with a non-zero window handle
- `git diff --check`
- `git ls-files --eol`