### PR TITLE
Keep taskbar and tray overflow open for non-activating flyouts

### DIFF
--- a/docs/system-tray-icon.md
+++ b/docs/system-tray-icon.md
@@ -53,6 +53,23 @@ private void TrayIcon_RightClicked(object? sender, MouseEventReceivedEventArgs e
 }
 ```
 
+## Keeping shell flyouts open
+
+On Windows, `SystemTrayIcon` activates its hidden callback window before raising a click event by default. This supports conventional native context menus, but it also causes shell-owned surfaces such as the notification area overflow to lose foreground activation.
+
+Disable that behavior when the click handler opens a non-activating `DesktopFlyout`:
+
+```csharp
+trayIcon.ActivateOnClick = false;
+flyout.ActivationMode = DesktopFlyoutActivationMode.NeverActivate;
+
+trayIcon.LeftClicked += (_, e) => flyout.Show(e.Point);
+```
+
+`NeverActivate` prevents later pointer interaction with the desktop flyout from activating it, allowing the shell overflow and an auto-hidden taskbar to remain open. `NoActivateOnOpen` can preserve the shell surface initially, but interacting with the desktop flyout can still activate it and dismiss the shell surface.
+
+Leave `ActivateOnClick` enabled when the click handler opens a conventional native context menu that requires its owner window to be in the foreground.
+
 ## Visibility and updates
 
 `IsVisible` defaults to `false`.

--- a/samples/DesktopFlyouts.Uwp.Sample.TrayHost/App.xaml.cs
+++ b/samples/DesktopFlyouts.Uwp.Sample.TrayHost/App.xaml.cs
@@ -26,7 +26,10 @@ namespace DesktopFlyouts
 			_systemTrayIcon = new(
 				"Tray.ico",
 				"DesktopFlyouts sample app (UWP)",
-				new("022F5158-F05A-4FE1-B356-34F14B363625"));
+				new("022F5158-F05A-4FE1-B356-34F14B363625"))
+			{
+				ActivateOnClick = false,
+			};
 
 			_systemTrayIcon.LeftClicked += SystemTrayIcon_LeftClicked;
 			_systemTrayIcon.RightClicked += SystemTrayIcon_RightClicked;

--- a/samples/DesktopFlyouts.Uwp.Sample.TrayHost/MainDesktopFlyout.xaml
+++ b/samples/DesktopFlyouts.Uwp.Sample.TrayHost/MainDesktopFlyout.xaml
@@ -8,6 +8,7 @@
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
 	Width="360"
+	ActivationMode="NeverActivate"
 	mc:Ignorable="d">
 
 	<local:DesktopFlyout.Resources>

--- a/samples/DesktopFlyouts.Wasdk.Sample.App/App.xaml.cs
+++ b/samples/DesktopFlyouts.Wasdk.Sample.App/App.xaml.cs
@@ -21,10 +21,15 @@ namespace DesktopFlyouts
 
         protected override void OnLaunched(LaunchActivatedEventArgs args)
         {
-            TrayIconManager.Default.Initialize(new(
+            var trayIcon = new SystemTrayIcon(
                 Path.Combine(Package.Current.InstalledLocation.Path, "Assets\\Tray.ico"),
                 "DesktopFlyouts sample app (WASDK)",
-                new("28DE460A-8BD6-4539-A406-5F685584FD4D")));
+                new("28DE460A-8BD6-4539-A406-5F685584FD4D"))
+            {
+                ActivateOnClick = false,
+            };
+
+            TrayIconManager.Default.Initialize(trayIcon);
 
             _window = new MainWindow();
             _window.Closed += (_, _) => TrayIconManager.Default.Dispose();

--- a/samples/DesktopFlyouts.Wasdk.Sample.App/ViewModels/RootViewModel.cs
+++ b/samples/DesktopFlyouts.Wasdk.Sample.App/ViewModels/RootViewModel.cs
@@ -77,7 +77,7 @@ namespace DesktopFlyouts
             ActivationModes.Add(DesktopFlyoutActivationMode.Activate, "Activate");
             ActivationModes.Add(DesktopFlyoutActivationMode.NoActivateOnOpen, "No activate on open");
             ActivationModes.Add(DesktopFlyoutActivationMode.NeverActivate, "Never activate");
-            SelectedActivationModeIndex = 0;
+            SelectedActivationModeIndex = 2;
 
             FlyoutExamples.Add(DesktopFlyoutSampleKind.Customizable, "Default");
             FlyoutExamples.Add(DesktopFlyoutSampleKind.Button, "Button");

--- a/src/DesktopFlyouts.Shared/DesktopMenuFlyout.cs
+++ b/src/DesktopFlyouts.Shared/DesktopMenuFlyout.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Drawing;
 using CommunityToolkit.WinUI;
+using Windows.Graphics;
 
 
 #if UWP
@@ -15,7 +16,6 @@ using Windows.Win32.UI.WindowsAndMessaging;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Markup;
-using Windows.Graphics;
 #endif
 
 namespace DesktopFlyouts

--- a/src/DesktopFlyouts.Shared/SystemTrayIcon.cs
+++ b/src/DesktopFlyouts.Shared/SystemTrayIcon.cs
@@ -92,6 +92,20 @@ namespace DesktopFlyouts
         }
 
         /// <summary>
+        /// Gets or sets whether the hidden callback window is activated before a click event is raised.
+        /// </summary>
+        /// <value><see langword="true"/> to activate the callback window before raising click and
+        /// double-click events; otherwise, <see langword="false"/>. The default is
+        /// <see langword="true"/>.</value>
+        /// <remarks>
+        /// Set this property to <see langword="false"/> when opening a non-activating desktop flyout
+        /// from a tray icon. This allows shell-owned surfaces, such as the notification area overflow,
+        /// to retain foreground activation. Conventional native context menus may require this property
+        /// to remain <see langword="true"/>.
+        /// </remarks>
+        public bool ActivateOnClick { get; set; } = true;
+
+        /// <summary>
         /// Gets the stable identifier used for the tray icon.
         /// </summary>
         /// <value>The GUID used by the shell to identify this notification icon.</value>
@@ -390,7 +404,9 @@ namespace DesktopFlyouts
                         {
                             case PInvoke.WM_LBUTTONUP:
                                 {
-                                    PInvoke.SetForegroundWindow(hWnd);
+                                    if (ActivateOnClick)
+                                        PInvoke.SetForegroundWindow(hWnd);
+
                                     var point = GetCenterPointOfTrayIcon(hWnd);
                                     if (!point.IsEmpty)
                                     {
@@ -401,7 +417,9 @@ namespace DesktopFlyouts
                                 }
                             case PInvoke.WM_RBUTTONUP:
                                 {
-                                    PInvoke.SetForegroundWindow(hWnd);
+                                    if (ActivateOnClick)
+                                        PInvoke.SetForegroundWindow(hWnd);
+
                                     var point = GetCenterPointOfTrayIcon(hWnd);
                                     if (!point.IsEmpty)
                                     {
@@ -412,7 +430,9 @@ namespace DesktopFlyouts
                                 }
                             case PInvoke.WM_LBUTTONDBLCLK:
                                 {
-                                    PInvoke.SetForegroundWindow(hWnd);
+                                    if (ActivateOnClick)
+                                        PInvoke.SetForegroundWindow(hWnd);
+
                                     var point = GetCenterPointOfTrayIcon(hWnd);
                                     if (!point.IsEmpty)
                                     {
@@ -423,7 +443,9 @@ namespace DesktopFlyouts
                                 }
                             case PInvoke.WM_RBUTTONDBLCLK:
                                 {
-                                    PInvoke.SetForegroundWindow(hWnd);
+                                    if (ActivateOnClick)
+                                        PInvoke.SetForegroundWindow(hWnd);
+
                                     var point = GetCenterPointOfTrayIcon(hWnd);
                                     if (!point.IsEmpty)
                                     {


### PR DESCRIPTION
## Summary

- add `SystemTrayIcon.ActivateOnClick` so tray callbacks can avoid taking foreground activation
- configure the Windows tray samples to combine `ActivateOnClick = false` with `DesktopFlyoutActivationMode.NeverActivate`
- document how this keeps shell-owned flyouts and an auto-hidden taskbar open
- make the `Windows.Graphics` import available to the UWP branch of `DesktopMenuFlyout`

`ActivateOnClick` defaults to `true`, preserving the existing behavior for conventional native context menus.

## Validation

- `dotnet msbuild /restore:false src/DesktopFlyouts.Uno/DesktopFlyouts.Uno.csproj /p:Configuration=Debug /p:Platform=x64 /p:AppxBundle=Never`
- `dotnet msbuild /restore:false samples/DesktopFlyouts.Wasdk.Sample.App/DesktopFlyouts.Wasdk.Sample.App.csproj /p:Configuration=Debug /p:Platform=x64 /p:AppxBundle=Never`
- `dotnet msbuild /restore:false src/DesktopFlyouts.Uwp/DesktopFlyouts.Uwp.csproj /p:Configuration=Debug /p:Platform=x64 /p:AppxBundle=Never`
- built the UWP TrayHost with Visual Studio MSBuild
- launched the packaged WinUI 3 sample and confirmed a responsive process with a non-zero window handle
- temporarily enabled taskbar auto-hide and confirmed that, 2.5 seconds after opening the sample flyout from the tray overflow, the overflow remained visible, Explorer remained foreground, and the taskbar remained expanded; restored the original taskbar setting afterward
- `git diff --check`
- confirmed all changed text files use CRLF
